### PR TITLE
Use List instead of Seq

### DIFF
--- a/src/main/scala/graphite4s/Graphite.scala
+++ b/src/main/scala/graphite4s/Graphite.scala
@@ -6,7 +6,7 @@ import com.typesafe.scalalogging.LazyLogging
 
 trait Graphite[M[_]] extends LazyLogging {
   def send(point: GraphitePoint): M[Unit]
-  def send(points: Seq[GraphitePoint]): M[Unit]
+  def send(points: List[GraphitePoint]): M[Unit]
 }
 
 class BaseGraphite[M[_]: Applicative](
@@ -17,9 +17,9 @@ class BaseGraphite[M[_]: Applicative](
     client.send(
       GraphitePoint.format(transformer.transform(point)).getBytes("UTF-8"))
 
-  override def send(points: Seq[GraphitePoint]): M[Unit] = {
+  override def send(points: List[GraphitePoint]): M[Unit] = {
     logger.info(s"#${points.length} points to send to graphite")
-    points.toList.traverse_(send)
+    points.traverse_(send)
   }
 }
 
@@ -28,7 +28,7 @@ class BatchGraphite[M[_]: Applicative](
     batchSize: Int = 1000,
     transformer: Transformer = NoTransformer
 ) extends BaseGraphite[M](client, transformer) {
-  override def send(points: Seq[GraphitePoint]): M[Unit] =
+  override def send(points: List[GraphitePoint]): M[Unit] =
     points
       .grouped(batchSize)
       .toList

--- a/src/test/scala/graphite4s/GraphiteTest.scala
+++ b/src/test/scala/graphite4s/GraphiteTest.scala
@@ -34,7 +34,7 @@ class GraphiteTest extends FlatSpec with Matchers {
     val mockClient = new MockClient()
     val graphite = new BaseGraphite(mockClient, new Prefixer("production"))
 
-    graphite.send(Seq(p1, p2))
+    graphite.send(List(p1, p2))
 
     mockClient.messages should contain theSameElementsInOrderAs Seq(
       "production.root.1 1.0 11\n",
@@ -47,7 +47,7 @@ class GraphiteTest extends FlatSpec with Matchers {
     val graphite =
       new BatchGraphite(mockClient, transformer = new Prefixer("production"))
 
-    graphite.send(Seq(p1, p2))
+    graphite.send(List(p1, p2))
 
     mockClient.messages should contain theSameElementsInOrderAs Seq(
       "production.root.1 1.0 11\nproduction.root.2 2.0 22\n"
@@ -61,7 +61,7 @@ class GraphiteTest extends FlatSpec with Matchers {
                         batchSize = 2,
                         transformer = new Prefixer("production"))
 
-    graphite.send(Seq(p1, p2, p3))
+    graphite.send(List(p1, p2, p3))
 
     mockClient.messages should contain theSameElementsInOrderAs Seq(
       "production.root.1 1.0 11\nproduction.root.2 2.0 22\n",


### PR DESCRIPTION
The problem with Seq is that it's too generic.
e.g. it can be a Stream so calling .toList might not work !